### PR TITLE
fix: adjust url to work in our environment

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export DOCKER_BUILDKIT=1
+sha=$(git rev-parse --short HEAD)
+echo $sha
+docker build -t asia.gcr.io/persuit-core/sendgrid-mock:$sha .
+docker push asia.gcr.io/persuit-core/sendgrid-mock:$sha

--- a/src/server/ExpressApp.js
+++ b/src/server/ExpressApp.js
@@ -96,7 +96,7 @@ const setupExpressApp = (
   });
   
   app.use(express.static(path.join(__dirname, '../../dist')));
-  app.get('/', function (req, res) {
+  app.get('/sendgridmock', function (req, res) {
     res.sendFile(path.join(__dirname, '../../dist', 'index.html'));
   });
   

--- a/src/server/ExpressApp.js
+++ b/src/server/ExpressApp.js
@@ -99,6 +99,10 @@ const setupExpressApp = (
   app.get('/sendgridmock', function (req, res) {
     res.sendFile(path.join(__dirname, '../../dist', 'index.html'));
   });
+
+  app.get('/', function (req, res) {
+    res.sendFile(path.join(__dirname, '../../dist', 'index.html'));
+  });
   
   return app;
 };


### PR DESCRIPTION
Our kubernetes environment uses paths to reach different services.

e.g `preview.npd.persuit.com/something`

This is a fork of the original sendGrid Mock that lets us use the `/sendgridmock` for ingress routing. 

I've also tried going left using `sendgridmock.preview.npd.persuit.com` but it requires multipule certs on the ingress which is quite a lot of work. 

## Testing
Can be run like so 
`docker run -p 3050:3000 asia.gcr.io/persuit-core/sendgrid-mock:960aa0a`
Then browse to http://localhost:3050/sendgridmock