### PR TITLE
fix: move to port 3050

### DIFF
--- a/src/server/Server.js
+++ b/src/server/Server.js
@@ -55,7 +55,7 @@ if (enableSsl) {
   asHttpsServer(app, sslRateLimitConfiguration);
 } else {
 
-  const serverPort = 3000;
+  const serverPort = 3050;
   app.listen(serverPort);
 
   logger.info(`Started sendgrid-mock on port ${serverPort}!`);


### PR DESCRIPTION
change port to 3050 which conflicts with other base port. 
`docker run -p 3050:3050 asia.gcr.io/persuit-core/sendgrid-mock:3783064`
